### PR TITLE
AUG-334 - Fix icon alignment for all buttons styles

### DIFF
--- a/dist/suprematism.css
+++ b/dist/suprematism.css
@@ -2898,7 +2898,11 @@ button, input[type="submit"] {
   padding: 0px; }
   button .u-supre-icon, input[type="submit"] .u-supre-icon {
     padding: 0 5px 0 0;
-    position: relative; }
+    font-size: 20px;
+    position: relative;
+    line-height: inherit;
+    display: inline-block;
+    vertical-align: top; }
   button.-action, input.-action[type="submit"] {
     color: #ffffff;
     line-height: 36px;
@@ -2942,11 +2946,6 @@ button, input[type="submit"] {
         border-color: inherit;
         color: #cccccc;
         box-shadow: inherit; }
-    button.-action .u-supre-icon, input.-action[type="submit"] .u-supre-icon {
-      font-size: 20px;
-      line-height: inherit;
-      display: inline-block;
-      vertical-align: top; }
   button.-dialog, input.-dialog[type="submit"] {
     color: #ffffff;
     line-height: 32px;
@@ -2956,9 +2955,6 @@ button, input[type="submit"] {
     background: #55a0c2;
     text-transform: uppercase;
     font-weight: bold; }
-    button.-dialog .u-supre-icon, input.-dialog[type="submit"] .u-supre-icon {
-      top: 4px;
-      font-size: 20px; }
   button.-dialog-reverse, input.-dialog-reverse[type="submit"] {
     color: #55a0c2;
     line-height: 32px;
@@ -2969,9 +2965,6 @@ button, input[type="submit"] {
     text-transform: uppercase;
     box-shadow: 0px 0px 0px 1px #55a0c2 inset;
     font-weight: bold; }
-    button.-dialog-reverse .u-supre-icon, input.-dialog-reverse[type="submit"] .u-supre-icon {
-      top: 4px;
-      font-size: 20px; }
   button.-toolbar, input.-toolbar[type="submit"] {
     color: #ffffff;
     line-height: 32px;
@@ -3016,9 +3009,6 @@ button, input[type="submit"] {
         box-shadow: inherit; }
     button.-toolbar + .-toolbar, input.-toolbar[type="submit"] + .-toolbar {
       border-left: 1px solid white; }
-    button.-toolbar .u-supre-icon, input.-toolbar[type="submit"] .u-supre-icon {
-      top: 4px;
-      font-size: 20px; }
   button.-cancel-lg, input.-cancel-lg[type="submit"] {
     color: #7f8a93;
     line-height: 36px;
@@ -3107,9 +3097,6 @@ button, input[type="submit"] {
         box-shadow: inherit; }
     button.-condition + .-condition, input.-condition[type="submit"] + .-condition {
       border-left: 3px solid white; }
-    button.-condition .u-supre-icon, input.-condition[type="submit"] .u-supre-icon {
-      top: 4px;
-      font-size: 20px; }
   button.-toggle, input.-toggle[type="submit"] {
     color: #6460aa;
     height: 32px;
@@ -3226,9 +3213,8 @@ button, input[type="submit"] {
     button.-toggle-action + .-toggle-action, input.-toggle-action[type="submit"] + .-toggle-action {
       margin-left: -1px; }
     button.-toggle-action .u-supre-icon, input.-toggle-action[type="submit"] .u-supre-icon {
-      top: 0px;
       font-size: 17px;
-      left: 3px; }
+      padding: 0px; }
 
 /**
  * Design Reference:

--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -38,6 +38,7 @@ $shadow-color: #4e4e4e;
 
 }
 
+
 button {
 
   // make sure they're clean
@@ -49,7 +50,11 @@ button {
   //
   .#{$icon-class} {
     padding: 0 5px 0 0;
+    font-size: $icon-size;
     position: relative;
+    line-height:inherit;
+    display:inline-block;
+    vertical-align:top;
   }
 
 
@@ -80,16 +85,6 @@ button {
       cursor: default;
     }
 
-    //
-    // Icon Rules
-    //
-    .#{$icon-class} {
-      font-size: $icon-size;
-      line-height:inherit;
-      display:inline-block;
-      vertical-align:top;
-    }
-
   }
 
 
@@ -107,13 +102,6 @@ button {
     text-transform: uppercase;
     font-weight: bold;
 
-    //
-    // Icon Rules
-    //
-    .#{$icon-class} {
-      top: 4px;
-      font-size: $icon-size;
-    }
 
   }
   &.-dialog-reverse {
@@ -127,13 +115,6 @@ button {
     box-shadow: 0px 0px 0px 1px $aqua inset;
     font-weight: bold;
 
-    //
-    // Icon Rules
-    //
-    .#{$icon-class} {
-      top: 4px;
-      font-size: $icon-size;
-    }
 
   }
 
@@ -167,14 +148,6 @@ button {
     // the next tool bar button should add a border to the left to seperate like the mock
     + .-toolbar {
       border-left: 1px solid white;
-    }
-
-    //
-    // Icon Rules
-    //
-    .#{$icon-class} {
-      top: 4px;
-      font-size: $icon-size;
     }
 
   }
@@ -233,14 +206,6 @@ button {
     // the next tool bar button should add a border to the left to seperate like the mock
     + .-condition {
       border-left: 3px solid white;
-    }
-
-    //
-    // Icon Rules
-    //
-    .#{$icon-class} {
-      top: 4px;
-      font-size: $icon-size;
     }
 
   }
@@ -335,9 +300,8 @@ button {
     // Icon Rules
     //
     .#{$icon-class} {
-      top: 0px;
       font-size: 17px;
-      left: 3px;
+      padding:0px;
     }
 
   }


### PR DESCRIPTION
This fixes button alignment for all button styles.  I moved 
```
font-size: $icon-size;
line-height:inherit;
display:inline-block;
vertical-align:top;
```
into the base button icon style to avoid repetition, and now override the necessary styles for toggle action buttons.

https://jira.inbcu.com/browse/AUG-334